### PR TITLE
Remove unused import subprocess

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,6 @@ from conans import ConanFile, AutoToolsBuildEnvironment
 from conans import tools
 from conans import __version__ as client_version
 import os
-import subprocess
 
 from conans.model.version import Version
 


### PR DESCRIPTION
`subprocess` is no longer in use since bea7144f61e784407f4a3c3b8aa04a2efaff9887.