### PR TITLE
Added support for no_async option

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,8 @@ class OpenSSLConan(ConanFile):
                "no_rc5": [True, False],
                "no_rsa": [True, False],
                "no_sha": [True, False],
-               "no_fpic": [True, False]}
+               "no_fpic": [True, False],
+               "no_async": [True, False]}
     default_options = "=False\n".join(options.keys()) + "=False"
 
     # When a new version is available they move the tar.gz to old/ location


### PR DESCRIPTION

This patch adds the no_async (no-async) option, which is required if you would like to get the code accepted by Apple. Also see https://github.com/openssl/openssl/issues/2545 