### PR TITLE
Enable Android x86_64 for OpenSSL 1.0.2 + move Configure changes to patch file

### DIFF
--- a/android.patch
+++ b/android.patch
@@ -1,0 +1,19 @@
+--- Configure	2017-12-07 14:16:38.000000000 +0100
++++ Configure_new	2019-03-13 09:54:41.200354600 +0100
+@@ -471,10 +471,12 @@
+ "linux-alpha+bwx-ccc","ccc:-fast -readonly_strings -DL_ENDIAN::-D_REENTRANT:::SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_PTR DES_RISC1 DES_UNROLL:${alpha_asm}",
+ 
+ # Android: linux-* but without pointers to headers and libs.
+-"android","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${no_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+-"android-x86","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:".eval{my $asm=${x86_elf_asm};$asm=~s/:elf/:android/;$asm}.":dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+-"android-armv7","gcc:-march=armv7-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+-"android-mips","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${mips32_asm}:o32:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android","clang:$ENV{'CFLAGS'} -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl $ENV{'LDFLAGS'}:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${no_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-x86","clang:$ENV{'CFLAGS'} -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl $ENV{'LDFLAGS'}:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:".eval{my $asm=${x86_elf_asm};$asm=~s/:elf/:android/;$asm}.":dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-x86_64","clang:$ENV{'CFLAGS'} -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl $ENV{'LDFLAGS'}:SIXTY_FOUR_BIT_LONG RC4_CHUNK DES_INT DES_UNROLL:${x86_64_asm}:elf:dlfcn:linux-shared:-fPIC:-m64:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR):::64",
++"android-armv7","clang:$ENV{'CFLAGS'} -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl $ENV{'LDFLAGS'}:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-aarch64","clang:$ENV{'CFLAGS'} -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl $ENV{'LDFLAGS'}:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${aarch64_asm}:linux64:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-mips","clang:$ENV{'CFLAGS'} -O3 -Wall::-D_REENTRANT::-ldl $ENV{'LDFLAGS'}:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${mips32_asm}:o32:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ 
+ #### *BSD [do see comment about ${BSDthreads} above!]
+ "BSD-generic32","gcc:-O3 -fomit-frame-pointer -Wall::${BSDthreads}:::BN_LLONG RC2_CHAR RC4_INDEX DES_INT DES_UNROLL:${no_asm}:dlfcn:bsd-gcc-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,6 +14,7 @@ class OpenSSLConan(ConanFile):
     license = "The current OpenSSL licence is an 'Apache style' license: https://www.openssl.org/source/license.html"
     description = "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured " \
                   "toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols"
+    exports_sources = ['android.patch']
     # https://github.com/openssl/openssl/blob/OpenSSL_1_0_2l/INSTALL
     options = {"no_threads": [True, False],
                "no_zlib": [True, False],
@@ -96,10 +97,7 @@ class OpenSSLConan(ConanFile):
             tools.replace_in_file("./%s/Configure" % self.subfolder, "::-lefence ", "::")
             self.output.info("=====> Options: %s" % config_options_string)
         if self.settings.os == "Android" and self.settings.compiler == "clang":
-            tools.replace_in_file("./openssl-%s/Configure" % self.version, 
-                                '''"android-armv7","gcc:-march=armv7-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",''',
-                                '''"android-armv7","clang:$ENV{'CFLAGS'} -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl $ENV{'LDFLAGS'}:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
-"android-aarch64","clang:-I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${aarch64_asm}:linux64:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",''')
+            tools.patch(base_path=self.subfolder, patch_file="android.patch")
 
         for option_name in self.options.values.fields:
             activated = getattr(self.options, option_name)
@@ -167,6 +165,8 @@ class OpenSSLConan(ConanFile):
                 target = "android-aarch64"
             elif self.settings.arch == "x86":
                 target = "android-x86"
+            elif self.settings.arch == "x86_64":
+                target = "android-x86_64"
             elif self.settings.arch == "mips":
                 target = "android-mips"
             else:

--- a/conanfile.py
+++ b/conanfile.py
@@ -65,6 +65,10 @@ class OpenSSLConan(ConanFile):
             raise Exception("This recipe only works with Conan client >= 1.0.0")
         del self.settings.compiler.libcxx
 
+        if self.settings.os == "Android":
+            # Build will fail without changing this option
+            self.default_options = self.default_options.replace("no_asm=False", "no_asm=True")
+
     def requirements(self):
         if not self.options.no_zlib:
             self.requires("zlib/1.2.11@conan/stable")

--- a/conanfile.py
+++ b/conanfile.py
@@ -65,10 +65,6 @@ class OpenSSLConan(ConanFile):
             raise Exception("This recipe only works with Conan client >= 1.0.0")
         del self.settings.compiler.libcxx
 
-        if self.settings.os == "Android":
-            # Build will fail without changing this option
-            self.default_options = self.default_options.replace("no_asm=False", "no_asm=True")
-
     def requirements(self):
         if not self.options.no_zlib:
             self.requires("zlib/1.2.11@conan/stable")
@@ -163,6 +159,7 @@ class OpenSSLConan(ConanFile):
                 raise Exception("Unsupported arch for Linux")
 
         elif self.settings.os == "Android":
+            config_options_string = " no-asm" + config_options_string
             if "armv7" in self.settings.arch:
                 target = "android-armv7"
             elif self.settings.arch == "armv8":


### PR DESCRIPTION
This adds last missing target `android-x86_64` to `Configure` and enables it in the `conanfile.py`. The patches are now applyed via patch file to keep the conanfile readable.
I tested the build for all supported arches (x86, x86_64, armv7, armv8) and everything builds fine when setting the "no_asm" option. I did not add mips64 (and did not test mips) since mips is not supported anymore with ndk r17c.
The changes are also needed in the `release/1.0.2n` branch for libcurl and they can be applied without changes (tested it, too).