### PR TITLE
Preserve symlinks on shared objects when packaging

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -324,8 +324,8 @@ class OpenSSLConan(ConanFile):
             if self.options.shared:
                 self.copy(pattern="*libcrypto*.dylib", dst="lib", keep_path=False)
                 self.copy(pattern="*libssl*.dylib", dst="lib", keep_path=False)
-                self.copy(pattern="*libcrypto.so*", dst="lib", keep_path=False)
-                self.copy(pattern="*libssl.so*", dst="lib", keep_path=False)
+                self.copy(pattern="*libcrypto.so*", dst="lib", keep_path=False, symlinks=True)
+                self.copy(pattern="*libssl.so*", dst="lib", keep_path=False, symlinks=True)
             else:
                 self.copy("*.a", "lib", keep_path=False)
 


### PR DESCRIPTION
This PR preserves the `*.so -> *.so.1.1` symlinks when packaging.  

Without this, a copy of `libcrypto.so.1.1` and `libssl.so.1.1` exist for each symlink, which doubles the space requirements for each shared object.